### PR TITLE
Timestamp debug

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,9 +71,12 @@ target_include_directories(example_control PUBLIC
 )
 install(TARGETS
   example_control
-  DESTINATION lib/${PROJECT_NAME})
+  DESTINATION lib/${PROJECT_NAME}
+)
 
-  add_executable(example_control_multi_rover src/example_control_multi_rover.cpp)
+
+
+add_executable(example_control_multi_rover src/example_control_multi_rover.cpp)
 ament_target_dependencies(example_control_multi_rover rclcpp px4_msgs geometry_msgs tf2 tf2_ros px4_ros_com) 
 target_link_libraries(example_control_multi_rover dascBots)
 target_include_directories(example_control_multi_rover PUBLIC
@@ -83,5 +86,21 @@ target_include_directories(example_control_multi_rover PUBLIC
 install(TARGETS
   example_control_multi_rover
   DESTINATION lib/${PROJECT_NAME})
+
+
+
+
+add_executable(example_control_geometric src/example_control_geometric.cpp)
+ament_target_dependencies(example_control_geometric rclcpp px4_msgs geometry_msgs tf2 tf2_ros px4_ros_com) 
+target_link_libraries(example_control_geometric dascBots)
+target_include_directories(example_control_geometric PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/${PROJECT_NAME}>
+  $<INSTALL_INTERFACE:include/${PROJECT_NAME}>
+)
+install(TARGETS
+  example_control_geometric
+  DESTINATION lib/${PROJECT_NAME}
+)
+
 
 ament_package()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,4 +103,30 @@ install(TARGETS
 )
 
 
+add_executable(example_control_geometric_velocity src/example_control_geometric_velocity.cpp)
+ament_target_dependencies(example_control_geometric_velocity rclcpp px4_msgs geometry_msgs tf2 tf2_ros px4_ros_com) 
+target_link_libraries(example_control_geometric_velocity dascBots)
+target_include_directories(example_control_geometric_velocity PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/${PROJECT_NAME}>
+  $<INSTALL_INTERFACE:include/${PROJECT_NAME}>
+)
+install(TARGETS
+  example_control_geometric_velocity
+  DESTINATION lib/${PROJECT_NAME}
+)
+
+
+add_executable(example_control_geometric_acceleration src/example_control_geometric_acceleration.cpp)
+ament_target_dependencies(example_control_geometric_acceleration rclcpp px4_msgs geometry_msgs tf2 tf2_ros px4_ros_com) 
+target_link_libraries(example_control_geometric_acceleration dascBots)
+target_include_directories(example_control_geometric_acceleration PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/${PROJECT_NAME}>
+  $<INSTALL_INTERFACE:include/${PROJECT_NAME}>
+)
+install(TARGETS
+  example_control_geometric_acceleration
+  DESTINATION lib/${PROJECT_NAME}
+)
+
+
 ament_package()

--- a/include/dasc_robot/DASCRobots.hpp
+++ b/include/dasc_robot/DASCRobots.hpp
@@ -5,6 +5,7 @@
 
 #include <rclcpp/rclcpp.hpp>
 #include <px4_msgs/msg/offboard_control_mode.hpp>
+#include <px4_msgs/msg/external_controller.hpp>
 #include <px4_msgs/msg/trajectory_setpoint.hpp>
 #include <px4_msgs/msg/timesync.hpp>
 #include <px4_msgs/msg/vehicle_command.hpp>
@@ -68,7 +69,8 @@ class DASCRobot : public DASC {
         bool getBodyRate(std::array<double, 3>& brate);
         bool getBodyQuaternion(std::array<double, 4>& quat, bool blocking);
         bool setCmdMode(DASCRobot::ControlMode mode);
-        bool cmdWorldPosition(double x, double y, double z, double yaw, double yaw_rate);
+        bool useExternalController(bool mode);
+	bool cmdWorldPosition(double x, double y, double z, double yaw, double yaw_rate);
         bool cmdWorldVelocity(double x, double y, double z, double yaw, double yaw_rate);
         bool cmdLocalVelocity(double x, double y, double z, double yaw, double yaw_rate);
         bool cmdWorldAcceleration(double x, double y, double z, double yaw, double yaw_rate);
@@ -86,6 +88,8 @@ class DASCRobot : public DASC {
         void emergencyStop();
         bool takeoff();
         bool land();
+        uint64_t get_current_timestamp(); // DEV: in what units? DEV: i thinks ms
+    
     private:
         enum class RobotServerState {
             kInit = 0,
@@ -136,6 +140,7 @@ class DASCRobot : public DASC {
         rclcpp::Subscription<VehicleLocalPosition>::SharedPtr vehicle_local_position_sub_;
 
         rclcpp::Publisher<OffboardControlMode>::SharedPtr offboard_control_mode_publisher_;
+        rclcpp::Publisher<ExternalController>::SharedPtr vehicle_useExternalController_publisher_;
         rclcpp::Publisher<TrajectorySetpoint>::SharedPtr trajectory_setpoint_publisher_;
         rclcpp::Publisher<VehicleCommand>::SharedPtr vehicle_command_publisher_;
         rclcpp::Publisher<VehicleAttitudeSetpoint>::SharedPtr vehicle_attitude_publisher_;
@@ -153,7 +158,6 @@ class DASCRobot : public DASC {
         void rateFSMUpdate();
         void controllerTimeoutFSMUpdate();
         void failsafeFSMUpdate();
-        uint64_t get_current_timestamp();
         double clampToPi(double yaw);
         std::array<double, 4> ned_to_enu(const std::array<double, 4> &quat);
         std::array<double, 4> enu_to_ned(const std::array<double, 4> &quat);

--- a/include/dasc_robot/DASCRobots.hpp
+++ b/include/dasc_robot/DASCRobots.hpp
@@ -88,7 +88,7 @@ class DASCRobot : public DASC {
         void emergencyStop();
         bool takeoff();
         bool land();
-        uint64_t get_current_timestamp(bool px4_sync = true, int mode = 0); 
+        uint64_t get_current_timestamp_us(bool px4_sync = true); 
     
     private:
         enum class RobotServerState {

--- a/include/dasc_robot/DASCRobots.hpp
+++ b/include/dasc_robot/DASCRobots.hpp
@@ -70,7 +70,7 @@ class DASCRobot : public DASC {
         bool getBodyQuaternion(std::array<double, 4>& quat, bool blocking);
         bool setCmdMode(DASCRobot::ControlMode mode);
         bool useExternalController(bool mode);
-	bool cmdWorldPosition(double x, double y, double z, double yaw, double yaw_rate);
+	    bool cmdWorldPosition(double x, double y, double z, double yaw, double yaw_rate);
         bool cmdWorldVelocity(double x, double y, double z, double yaw, double yaw_rate);
         bool cmdLocalVelocity(double x, double y, double z, double yaw, double yaw_rate);
         bool cmdWorldAcceleration(double x, double y, double z, double yaw, double yaw_rate);
@@ -88,7 +88,7 @@ class DASCRobot : public DASC {
         void emergencyStop();
         bool takeoff();
         bool land();
-        uint64_t get_current_timestamp(); // DEV: in what units? DEV: i thinks ms
+        uint64_t get_current_timestamp(bool px4_sync = true, int mode = 0); 
     
     private:
         enum class RobotServerState {

--- a/src/DASCRobots.cpp
+++ b/src/DASCRobots.cpp
@@ -105,7 +105,7 @@ bool DASCRobot::arm() {
         return false;
     }
     VehicleCommand msg;
-    msg.timestamp = get_current_timestamp();
+    msg.timestamp = get_current_timestamp_us();
     msg.param1 = 1.0;
     msg.param2 = 0.0; // set param2 to 21196 to force arm/disarm operation
     msg.command = VehicleCommand::VEHICLE_CMD_COMPONENT_ARM_DISARM;
@@ -124,7 +124,7 @@ bool DASCRobot::disarm() {
         return false;
     }
     VehicleCommand msg;
-    msg.timestamp = get_current_timestamp();
+    msg.timestamp = get_current_timestamp_us();
     msg.param1 = 0.0;
     msg.param2 = 21196; // set param2 to 21196 to force arm/disarm operation
     msg.command = VehicleCommand::VEHICLE_CMD_COMPONENT_ARM_DISARM;
@@ -260,7 +260,7 @@ bool DASCRobot::useExternalController(bool mode){
     }
 
     ExternalController msg;
-    msg.timestamp = get_current_timestamp();
+    msg.timestamp = get_current_timestamp_us();
     msg.use_geometric_control = mode;
 
     // RCLCPP_INFO(this->get_logger(), "Setting Geometric Control use to %d", mode);
@@ -322,7 +322,7 @@ bool DASCRobot::cmdWorldPosition(double x, double y, double z, double yaw, doubl
     }
     this->last_publish_timestamp_ = this->get_clock()->now().nanoseconds();
     TrajectorySetpoint msg;
-    msg.timestamp = get_current_timestamp();
+    msg.timestamp = get_current_timestamp_us();
     msg.x = y;
     msg.y = x;
     msg.z = -z;
@@ -346,7 +346,7 @@ bool DASCRobot::cmdWorldVelocity(double x, double y, double z, double yaw, doubl
     }
     this->last_publish_timestamp_ = this->get_clock()->now().nanoseconds();
     TrajectorySetpoint msg;
-    msg.timestamp = get_current_timestamp();
+    msg.timestamp = get_current_timestamp_us();
     msg.x = NAN;
     msg.y = NAN;
     msg.z = NAN;
@@ -370,7 +370,7 @@ bool DASCRobot::cmdLocalVelocity(double x, double y, double z, double yaw, doubl
     }
     this->last_publish_timestamp_ = this->get_clock()->now().nanoseconds();
     TrajectorySetpoint msg;
-    msg.timestamp = get_current_timestamp();
+    msg.timestamp = get_current_timestamp_us();
     msg.x = NAN;
     msg.y = NAN;
     msg.z = NAN;
@@ -393,7 +393,7 @@ bool DASCRobot::cmdWorldAcceleration(double x, double y, double z, double yaw, d
     }
     this->last_publish_timestamp_ = this->get_clock()->now().nanoseconds();
     TrajectorySetpoint msg;
-    msg.timestamp = get_current_timestamp();
+    msg.timestamp = get_current_timestamp_us();
     msg.x = NAN;
     msg.y = NAN;
     msg.z = NAN;
@@ -419,7 +419,7 @@ bool DASCRobot::cmdAttitude(double q_w, double q_x, double q_y, double q_z, doub
     }
     this->last_publish_timestamp_ = this->get_clock()->now().nanoseconds();
     VehicleAttitudeSetpoint msg;
-    msg.timestamp = get_current_timestamp();
+    msg.timestamp = get_current_timestamp_us();
     msg.roll_body = NAN;
     msg.pitch_body = NAN;
     msg.yaw_body = NAN;
@@ -442,7 +442,7 @@ bool DASCRobot::cmdRates(double roll, double pitch, double yaw, double thrust) {
     }
     this->last_publish_timestamp_ = this->get_clock()->now().nanoseconds();
     VehicleRatesSetpoint msg;
-    msg.timestamp = get_current_timestamp();
+    msg.timestamp = get_current_timestamp_us();
     msg.roll = roll;
     msg.pitch = -pitch;
     msg.yaw = -yaw;
@@ -458,7 +458,7 @@ bool DASCRobot::cmdOffboardMode() {
         return false;
     }
     VehicleCommand msg;
-    msg.timestamp = get_current_timestamp();
+    msg.timestamp = get_current_timestamp_us();
     msg.command = VehicleCommand::VEHICLE_CMD_DO_SET_MODE;
     msg.param1 = 1;
     msg.param2 = 6; // PX4_CUSTOM_MAIN_MODE_OFFBOARD
@@ -628,7 +628,7 @@ void DASCRobot::updateState() {
 
 void DASCRobot::positionFSMUpdate() {
     OffboardControlMode msg;
-    msg.timestamp = get_current_timestamp();
+    msg.timestamp = get_current_timestamp_us();
     msg.position = true;
     offboard_control_mode_publisher_->publish(msg);
     // std::cout << "Send offboard position command \n"; 
@@ -643,7 +643,7 @@ void DASCRobot::velocityFSMUpdate() {
     }
     else {
         OffboardControlMode msg;
-        msg.timestamp = get_current_timestamp();
+        msg.timestamp = get_current_timestamp_us();
         msg.velocity = true;
         offboard_control_mode_publisher_->publish(msg);
         // std::cout << "Send offboard velocity command \n"; 
@@ -659,7 +659,7 @@ void DASCRobot::accelerationFSMUpdate() {
     }
     else {
         OffboardControlMode msg;
-        msg.timestamp = get_current_timestamp();
+        msg.timestamp = get_current_timestamp_us();
         msg.acceleration = true;
         offboard_control_mode_publisher_->publish(msg);
     }
@@ -674,7 +674,7 @@ void DASCRobot::attitudeFSMUpdate() {
     }
     else {
         OffboardControlMode msg;
-        msg.timestamp = get_current_timestamp();
+        msg.timestamp = get_current_timestamp_us();
         msg.attitude = true;
         offboard_control_mode_publisher_->publish(msg);
     }
@@ -689,7 +689,7 @@ void DASCRobot::rateFSMUpdate() {
     }
     else {
         OffboardControlMode msg;
-        msg.timestamp = get_current_timestamp();
+        msg.timestamp = get_current_timestamp_us();
         msg.body_rate = true;
         offboard_control_mode_publisher_->publish(msg);
     }
@@ -703,7 +703,7 @@ void DASCRobot::controllerTimeoutFSMUpdate() {
          * https://github.com/PX4/PX4-Autopilot/blob/master/src/modules/commander/Commander.cpp
          */
         VehicleCommand msg;
-        msg.timestamp = get_current_timestamp();
+        msg.timestamp = get_current_timestamp_us();
         msg.command = VehicleCommand::VEHICLE_CMD_DO_SET_MODE;
         msg.param1 = 1;
         msg.param2 = 4; // PX4_CUSTOM_MAIN_MODE_AUTO
@@ -741,7 +741,7 @@ void DASCRobot::controllerTimeoutFSMUpdate() {
 void DASCRobot::failsafeFSMUpdate() {
     if (this->server_state_ == RobotServerState::kFailSafe) {
         VehicleCommand msg;
-        msg.timestamp = get_current_timestamp();
+        msg.timestamp = get_current_timestamp_us();
         msg.command = VehicleCommand::VEHICLE_CMD_DO_SET_MODE;
         msg.param1 = 1;
         msg.param2 = 4; // PX4_CUSTOM_MAIN_MODE_AUTO
@@ -766,7 +766,7 @@ void DASCRobot::failsafeFSMUpdate() {
 
 void DASCRobot::emergencyStop() {
     VehicleCommand msg;
-    msg.timestamp = get_current_timestamp();
+    msg.timestamp = get_current_timestamp_us();
     msg.command = VehicleCommand::VEHICLE_CMD_COMPONENT_ARM_DISARM;
     msg.param1 = VehicleCommand::ARMING_ACTION_DISARM;
     msg.param2 = 21196; // set param2 to 21196 to force arm/disarm operation
@@ -784,7 +784,7 @@ void DASCRobot::setGPSGlobalOrigin(double lat, double lon, double alt) {
      * https://github.com/PX4/PX4-Autopilot/blob/master/msg/vehicle_command.msg
      */
     VehicleCommand msg;
-    msg.timestamp = get_current_timestamp();
+    msg.timestamp = get_current_timestamp_us();
     msg.command = VehicleCommand::VEHICLE_CMD_SET_GPS_GLOBAL_ORIGIN;
     msg.param5 = lat;
     msg.param6 = lon;
@@ -824,33 +824,24 @@ std::array<double, 4> DASCRobot::enu_to_ned(const std::array<double, 4> &quat) {
 }
 
 /*
- Returns timestamp in milliseconds
+ Returns timestamp in microseconds
 
  Arguments 
  px4_sync: DEFAULT is true as most calls need syncing (to send commands or to get data)
            option2 is false when user wants ROS time for contriolling multiple robots and does not care about individual px4 syncing
- mode: 0 - microseconds: DEFAULT for all send command messages
-       1 - milli seconds: if user wants
 */
-uint64_t DASCRobot::get_current_timestamp(bool px4_sync, int mode) {
-    auto delta = (this->get_clock()->now().nanoseconds() - this->px4_server_timestamp_);// this is in ns
-
-    // RCLCPP_INFO(this->get_logger(), "px4: %lu", (unsigned long)px4_timestamp_.load());
-    // RCLCPP_INFO(this->get_logger(), "ros: %lu", (unsigned long)(this->get_clock()->now().nanoseconds()));
-    // RCLCPP_INFO(this->get_logger(), "delta: %lu", (unsigned long)delta);
-    // RCLCPP_INFO(this->get_logger(), "time: %lu", (unsigned long)(px4_timestamp_.load() + delta));
-
+uint64_t DASCRobot::get_current_timestamp_us(bool px4_sync) {
     if (px4_sync){
-        if (mode == 0)                                              // microseconds
-            return px4_timestamp_.load() + delta / 1000;
-        else                                                        // milliseconds
-            return px4_timestamp_.load() / 1000  + delta / 1e6;
+        auto delta = (this->get_clock()->now().nanoseconds() - this->px4_server_timestamp_);// this is in ns
+
+        // RCLCPP_INFO(this->get_logger(), "px4: %lu", (unsigned long)px4_timestamp_.load());
+        // RCLCPP_INFO(this->get_logger(), "ros: %lu", (unsigned long)(this->get_clock()->now().nanoseconds()));
+        // RCLCPP_INFO(this->get_logger(), "delta: %lu", (unsigned long)delta);
+        // RCLCPP_INFO(this->get_logger(), "time: %lu", (unsigned long)(px4_timestamp_.load() + delta));
+
+        return px4_timestamp_.load() + delta / 1000;
     }
     else{
-        if (mode == 0)                                              // microseconds
-            return this->get_clock()->now().nanoseconds() / 1000;
-        else                                                        // milliseconds
-            return this->get_clock()->now().nanoseconds() / 1e6;
+        return this->get_clock()->now().nanoseconds() / 1000;
     }
-
 }

--- a/src/dasc_robot_lib.cpp
+++ b/src/dasc_robot_lib.cpp
@@ -38,7 +38,7 @@ extern "C" {
 
     bool arm(DASCRobot *robot) {return robot->arm();}
     bool disarm(DASCRobot *robot) {return robot->disarm();}
-    uint64_t get_current_timestamp(DASCRobot *robot, bool px4_sync, int mode) { return robot->get_current_timestamp(px4_sync, mode); }
+    uint64_t get_current_timestamp_us(DASCRobot *robot, bool px4_sync, int mode) { return robot->get_current_timestamp_us(px4_sync, mode); }
     bool getWorldPosition(DASCRobot *robot, std::array<double, 3>& pos) { return robot->getWorldPosition(pos);}
     bool getWorldVelocity(DASCRobot *robot, std::array<double, 3>&vel) {return robot->getWorldVelocity(vel);}
     bool getWorldAcceleration(DASCRobot *robot, std::array<double, 3>&acc) {return robot->getWorldAcceleration(acc);}    

--- a/src/dasc_robot_lib.cpp
+++ b/src/dasc_robot_lib.cpp
@@ -38,7 +38,7 @@ extern "C" {
 
     bool arm(DASCRobot *robot) {return robot->arm();}
     bool disarm(DASCRobot *robot) {return robot->disarm();}
-
+    uint64_t get_current_timestamp(DASCRobot *robot, bool px4_sync, int mode) { return robot->get_current_timestamp(px4_sync, mode); }
     bool getWorldPosition(DASCRobot *robot, std::array<double, 3>& pos) { return robot->getWorldPosition(pos);}
     bool getWorldVelocity(DASCRobot *robot, std::array<double, 3>&vel) {return robot->getWorldVelocity(vel);}
     bool getWorldAcceleration(DASCRobot *robot, std::array<double, 3>&acc) {return robot->getWorldAcceleration(acc);}    

--- a/src/dasc_robot_lib.cpp
+++ b/src/dasc_robot_lib.cpp
@@ -46,6 +46,7 @@ extern "C" {
     bool getBodyRate(DASCRobot *robot, std::array<double, 3>&brate) {return robot->getBodyRate(brate);}
     bool getBodyQuaternion(DASCRobot *robot, std::array<double, 4>& quat, bool blocking) { return robot->getBodyQuaternion(quat, blocking); }
     bool setCmdMode(DASCRobot *robot, int mode) {return robot->setCmdMode(static_cast<DASC::ControlMode>(mode));}
+    bool useExternalController(DASCRobot *robot, bool mode) { return robot->useExternalController(mode); }
     bool cmdWorldPosition(DASCRobot *robot, double x, double y, double z, double yaw, double yaw_rate) {return robot->cmdWorldPosition(x, y, z, yaw, yaw_rate);}
     bool cmdWorldVelocity(DASCRobot *robot, double x, double y, double z, double yaw, double yaw_rate) {return robot->cmdWorldVelocity(x, y, z, yaw, yaw_rate);}
     bool cmdLocalVelocity(DASCRobot *robot, double x, double y, double z, double yaw, double yaw_rate) {

--- a/src/example_control_geometric.cpp
+++ b/src/example_control_geometric.cpp
@@ -1,0 +1,77 @@
+#include <thread>
+#include "DASCRobots.hpp"
+
+
+int main(int argc, char* argv[]) {
+	std::cout << "Starting offboard control node..." << std::endl;
+	setvbuf(stdout, NULL, _IONBF, BUFSIZ);
+	rclcpp::init(argc, argv);
+
+    auto rover = std::make_shared<DASCRobot>("drone1", 1);
+    
+    rover->init();
+    
+    rclcpp::executors::MultiThreadedExecutor server_exec;
+    server_exec.add_node(rover);
+    
+    auto server_spin_exec = [&server_exec]() {
+        server_exec.spin();
+    };
+    std::thread server_exec_thread(server_spin_exec);
+    std::cout << "Node init" << std::endl;
+    std::this_thread::sleep_for(std::chrono::milliseconds(2000));
+    std::cout << "Node start" << std::endl;
+
+    rover->setCmdMode(DASCRobot::ControlMode::kPositionMode);
+   
+    for (int i = 0; i < 100; i++) {
+	rover->cmdWorldPosition(0, 0, 0.50, 0, 0.0);
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    }
+    
+    rover->cmdOffboardMode();
+    rover->useExternalController(true);
+    rover->arm();
+    
+    std::cout << "Arm" << std::endl;
+    std::cout << "in loop" << std::endl;
+
+    auto start = rover->get_current_timestamp();
+
+    while(rclcpp::ok()) {
+
+	//rover->cmdWorldPosition(0,0,0.5,0,0);
+	auto now = rover->get_current_timestamp();
+
+        auto elapsed = now - start;
+
+	if (elapsed <= 10000*1000) {
+                rover->cmdWorldPosition(0.0, 0.0, 0.5, 0, 0);
+		std::cout << "Elapsed " << elapsed << "; CMD: 0.5" << std::endl;
+	}
+	else if (elapsed <= 15000*1000) {
+	        rover->cmdWorldPosition(0.0, 0.0, 0.0, 0, 0);
+		std::cout << "Elapsed " << elapsed << "; CMD: 0.0" << std::endl;
+	}
+	else{
+		break;
+	}
+
+        rover->useExternalController(true);
+	std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    }
+
+    // disarm
+    std::cout << "before DISARM" << std::endl;
+    rover->disarm();
+    std::cout << "after disarm" << std::endl;
+
+
+    server_exec_thread.join();
+    std::cout << "after .join() " << std::endl;
+
+    rclcpp::shutdown();
+    std::cout << "after shutdown" << std::endl;
+
+    return 0;
+}

--- a/src/example_control_geometric.cpp
+++ b/src/example_control_geometric.cpp
@@ -36,12 +36,12 @@ int main(int argc, char* argv[]) {
     std::cout << "Arm" << std::endl;
     std::cout << "in loop" << std::endl;
 
-    auto start = rover->get_current_timestamp();
+    auto start = rover->get_current_timestamp_us();
 
     while(rclcpp::ok()) {
 
         //rover->cmdWorldPosition(0,0,0.5,0,0);
-        auto now = rover->get_current_timestamp();
+        auto now = rover->get_current_timestamp_us();
 
         auto elapsed = now - start;
 

--- a/src/example_control_geometric.cpp
+++ b/src/example_control_geometric.cpp
@@ -40,25 +40,24 @@ int main(int argc, char* argv[]) {
 
     while(rclcpp::ok()) {
 
-	//rover->cmdWorldPosition(0,0,0.5,0,0);
-	auto now = rover->get_current_timestamp();
+        //rover->cmdWorldPosition(0,0,0.5,0,0);
+        auto now = rover->get_current_timestamp();
 
         auto elapsed = now - start;
 
-	if (elapsed <= 10000*1000) {
-                rover->cmdWorldPosition(0.0, 0.0, 0.5, 0, 0);
-		std::cout << "Elapsed " << elapsed << "; CMD: 0.5" << std::endl;
-	}
-	else if (elapsed <= 15000*1000) {
-	        rover->cmdWorldPosition(0.0, 0.0, 0.0, 0, 0);
-		std::cout << "Elapsed " << elapsed << "; CMD: 0.0" << std::endl;
-	}
-	else{
-		break;
-	}
-
+        if (elapsed <= 10000*1000) {
+            rover->cmdWorldPosition(0.0, 0.0, 0.5, 0, 0);
+            std::cout << "Elapsed " << elapsed << "; CMD: 0.5" << std::endl;
+        }
+        else if (elapsed <= 15000*1000) {
+            rover->cmdWorldPosition(0.0, 0.0, 0.0, 0, 0);
+            std::cout << "Elapsed " << elapsed << "; CMD: 0.0" << std::endl;
+        }
+        else{
+            break;
+        }
         rover->useExternalController(true);
-	std::this_thread::sleep_for(std::chrono::milliseconds(50));
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
     }
 
     // disarm

--- a/src/example_control_geometric_acceleration.cpp
+++ b/src/example_control_geometric_acceleration.cpp
@@ -36,7 +36,7 @@ int main(int argc, char* argv[]) {
     std::cout << "Arm" << std::endl;
     std::cout << "in loop" << std::endl;
 
-    auto start = rover->get_current_timestamp();
+    auto start = rover->get_current_timestamp_us();
 
     std::array<double, 3> pos_err_int {0,0,0};
 
@@ -46,7 +46,7 @@ int main(int argc, char* argv[]) {
 	std::array<double, 3> des_pos {0.0, 0.0, 0.0};
 	std::array<double, 3> des_vel {0.0, 0.0, 0.0};
 	
-	auto now = rover->get_current_timestamp();
+	auto now = rover->get_current_timestamp_us();
 
         auto elapsed = now - start;
 

--- a/src/example_control_geometric_acceleration.cpp
+++ b/src/example_control_geometric_acceleration.cpp
@@ -1,0 +1,106 @@
+#include <thread>
+#include "DASCRobots.hpp"
+
+
+int main(int argc, char* argv[]) {
+	std::cout << "Starting offboard control node..." << std::endl;
+	setvbuf(stdout, NULL, _IONBF, BUFSIZ);
+	rclcpp::init(argc, argv);
+
+    auto rover = std::make_shared<DASCRobot>("drone1", 1);
+    
+    rover->init();
+    
+    rclcpp::executors::MultiThreadedExecutor server_exec;
+    server_exec.add_node(rover);
+    
+    auto server_spin_exec = [&server_exec]() {
+        server_exec.spin();
+    };
+    std::thread server_exec_thread(server_spin_exec);
+    std::cout << "Node init" << std::endl;
+    std::this_thread::sleep_for(std::chrono::milliseconds(2000));
+    std::cout << "Node start" << std::endl;
+
+    rover->setCmdMode(DASCRobot::ControlMode::kAccelerationMode);
+   
+    for (int i = 0; i < 100; i++) {
+	rover->cmdWorldAcceleration(0, 0, 0.0, 0, 0.0);
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    }
+    
+    rover->cmdOffboardMode();
+    rover->useExternalController(true);
+    rover->arm();
+    
+    std::cout << "Arm" << std::endl;
+    std::cout << "in loop" << std::endl;
+
+    auto start = rover->get_current_timestamp();
+
+    std::array<double, 3> pos_err_int {0,0,0};
+
+
+    while(rclcpp::ok()) {
+
+	std::array<double, 3> des_pos {0.0, 0.0, 0.0};
+	std::array<double, 3> des_vel {0.0, 0.0, 0.0};
+	
+	auto now = rover->get_current_timestamp();
+
+        auto elapsed = now - start;
+
+	if (elapsed <= 10000*1000) {
+		des_pos[2] = 0.5;
+	}
+	else if (elapsed <= 15000*1000) {
+		des_pos[2] = 0.0;
+	}
+	else{
+		break;
+	}
+
+	// feedback control
+	double kp = 4.50;
+	double kv = 2.50;
+	double ki = 0.05;
+
+        std::array<double, 3> current_pos = rover->getWorldPosition();
+        std::array<double, 3> current_vel = rover->getWorldVelocity();
+	
+	std::array<double, 3> des_acc { 0,0,0};
+	
+	for (int i=0; i < 3 ; i++ ){
+		double e_pos = current_pos[i] - des_pos[i];
+		double e_vel = current_vel[i] - des_vel[i];
+
+		pos_err_int[i] += e_pos;
+
+		des_acc[i] = - kp * e_pos - kv * e_vel - ki * pos_err_int[i];
+
+	}
+
+	std::cout << "z_err: " << current_pos[2] - des_pos[2] << "\n";
+	// send the command
+        rover->cmdWorldAcceleration(des_acc[0], des_acc[1], des_acc[2], 0, 0);
+
+	//std::cout << "Elapsed " << elapsed << "; CMD: " << des_pos[2] << std::endl;
+
+        rover->useExternalController(true);
+	std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    }
+
+    // disarm
+    std::cout << "before DISARM" << std::endl;
+    rover->disarm();
+    std::cout << "after disarm" << std::endl;
+
+
+    server_exec_thread.join();
+    std::cout << "after .join() " << std::endl;
+
+    rclcpp::shutdown();
+    std::cout << "after shutdown" << std::endl;
+
+    return 0;
+}

--- a/src/example_control_geometric_velocity.cpp
+++ b/src/example_control_geometric_velocity.cpp
@@ -1,0 +1,93 @@
+#include <thread>
+#include "DASCRobots.hpp"
+
+
+int main(int argc, char* argv[]) {
+	std::cout << "Starting offboard control node..." << std::endl;
+	setvbuf(stdout, NULL, _IONBF, BUFSIZ);
+	rclcpp::init(argc, argv);
+
+    auto rover = std::make_shared<DASCRobot>("drone1", 1);
+    
+    rover->init();
+    
+    rclcpp::executors::MultiThreadedExecutor server_exec;
+    server_exec.add_node(rover);
+    
+    auto server_spin_exec = [&server_exec]() {
+        server_exec.spin();
+    };
+    std::thread server_exec_thread(server_spin_exec);
+    std::cout << "Node init" << std::endl;
+    std::this_thread::sleep_for(std::chrono::milliseconds(2000));
+    std::cout << "Node start" << std::endl;
+
+    rover->setCmdMode(DASCRobot::ControlMode::kVelocityMode);
+   
+    for (int i = 0; i < 100; i++) {
+	rover->cmdWorldVelocity(0, 0, 0.0, 0, 0.0);
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    }
+    
+    rover->cmdOffboardMode();
+    rover->useExternalController(true);
+    rover->arm();
+    
+    std::cout << "Arm" << std::endl;
+    std::cout << "in loop" << std::endl;
+
+    auto start = rover->get_current_timestamp();
+
+    while(rclcpp::ok()) {
+
+	std::array<double, 3> des_pos {0.0, 0.0, 0.0};
+
+	//rover->cmdWorldPosition(0,0,0.5,0,0);
+	auto now = rover->get_current_timestamp();
+
+        auto elapsed = now - start;
+
+	if (elapsed <= 10000*1000) {
+		des_pos[2] = 0.5;
+	}
+	else if (elapsed <= 15000*1000) {
+		des_pos[2] = 0.0;
+	}
+	else{
+		break;
+	}
+
+	// feedback control
+	double kp = 2.0;
+        std::array<double, 3> current_pos = rover->getWorldPosition();
+	std::array<double, 3> des_vel { 0,0,0};
+	
+	//std::cout << "current_pos: ";
+	for (int i=0; i < 3 ; i++ ){
+		des_vel[i] = - kp * (current_pos[i] - des_pos[i]);
+		//std::cout << current_pos[i] << " ";
+	}
+	//std::cout << "\n";
+
+	// send the command
+        rover->cmdWorldVelocity(des_vel[0], des_vel[1], des_vel[2], 0, 0);
+        std::cout << "Elapsed " << elapsed << "; CMD: " << des_pos[2] << std::endl;
+
+        rover->useExternalController(true);
+	std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    }
+
+    // disarm
+    std::cout << "before DISARM" << std::endl;
+    rover->disarm();
+    std::cout << "after disarm" << std::endl;
+
+
+    server_exec_thread.join();
+    std::cout << "after .join() " << std::endl;
+
+    rclcpp::shutdown();
+    std::cout << "after shutdown" << std::endl;
+
+    return 0;
+}

--- a/src/example_control_geometric_velocity.cpp
+++ b/src/example_control_geometric_velocity.cpp
@@ -36,14 +36,14 @@ int main(int argc, char* argv[]) {
     std::cout << "Arm" << std::endl;
     std::cout << "in loop" << std::endl;
 
-    auto start = rover->get_current_timestamp();
+    auto start = rover->get_current_timestamp_us();
 
     while(rclcpp::ok()) {
 
 	std::array<double, 3> des_pos {0.0, 0.0, 0.0};
 
 	//rover->cmdWorldPosition(0,0,0.5,0,0);
-	auto now = rover->get_current_timestamp();
+	auto now = rover->get_current_timestamp_us();
 
         auto elapsed = now - start;
 


### PR DESCRIPTION
framework was adding microseconds from px4 time to milliseconds from ros time. corrected that. added two arguments to get timestamp function. First one 'time_sync' to know if user wants to sync with px4 time or not (by default it syncs as all send_command functions should have it), and another argument 'mode' for specifying time units: 0 for microseconds (default as all send offboard commands should be populated with micro-seconds that is px4's default) and 1 for milliseconds (see python node for example usage). changes compatible with latest pull request from robot-framework-py.